### PR TITLE
A really random source for the uuids

### DIFF
--- a/uuid.erl
+++ b/uuid.erl
@@ -34,7 +34,8 @@
 
 % Generates a random binary UUID.
 v4() ->
-  v4(random:uniform(round(math:pow(2, 48))) - 1, random:uniform(round(math:pow(2, 12))) - 1, random:uniform(round(math:pow(2, 32))) - 1, random:uniform(round(math:pow(2, 30))) - 1).
+  v4(crypto:rand_uniform(1, round(math:pow(2, 48))) - 1, crypto:rand_uniform(1, round(math:pow(2, 12))) - 1, crypto:rand_uniform(1, round(math:pow(2, 32))) - 1, crypto:rand_uniform(1, round(math:pow(2, 30))) - 1).
+
 v4(R1, R2, R3, R4) ->
     <<R1:48, 4:4, R2:12, 2:2, R3:32, R4: 30>>.
 


### PR DESCRIPTION
Changed random number generator to crypto:rand_uniform(), so that the uuids are not always the same sequence. I guess that is the idea of a uuid? I had trouble, because the uuids always were the same after restarting the erlang vm.
