### PR TITLE
Do not import random.

### DIFF
--- a/uuid.erl
+++ b/uuid.erl
@@ -30,7 +30,6 @@
 %
 -module(uuid).
 -export([v4/0, to_string/1, get_parts/1, to_binary/1]).
--import(random).
 
 % Generates a random binary UUID.
 v4() ->


### PR DESCRIPTION
As part of R16, support for packages has been removed. It seems to me that the `import` attribute, in the context of `uuid.erl` is of very little help. Therefore, I'm deleting it, so that it is possible to compile the module under R16. 
