### PR TITLE
fix a bug on to_binary/1

### DIFF
--- a/src/uuid.erl
+++ b/src/uuid.erl
@@ -49,7 +49,7 @@ get_parts(<<TL:32, TM:16, THV:16, CSR:8, CSL:8, N:48>>) ->
 % Converts a UUID string in the format of 550e8400-e29b-41d4-a716-446655440000
 % (with or without the dashes) to binary.
 to_binary(U)->
-    convert(lists:filter(fun(Elem) -> Elem /= $- end, U), []).
+    unicode:characters_to_binary(to_string(U)).
 
 % Converts a list of pairs of hex characters (00-ff) to bytes.
 convert([], Acc)->


### PR DESCRIPTION
```
2> uuid:to_binary(uuid:v4()).
** exception error: no function clause matching lists:'-filter/2-lc$^0/1-0-'(<<148,5,248,17,164,141,76,236,146,74,68,108,101,149,252,
                                                                               229>>) (lists.erl, line 1271)
     in function  uuid:to_binary/1 (uuid.erl, line 54)
```
